### PR TITLE
Fix #19 Advanced Data Processing - Error loading dataset: 'Dataitem' …

### DIFF
--- a/src/modeling/data/dataset_loader.py
+++ b/src/modeling/data/dataset_loader.py
@@ -151,6 +151,20 @@ def _preprocess_sample(data: list[dict]) -> list[DatasetItem]:
     return preprocessed_samples
 
 
+def _build_dataset_metadata(samples: list[DatasetItem]) -> DatasetMetadata:
+    # Generate metadata
+    labels = set([s.label for s in samples])
+
+    # Sort and print unique labels
+    sorted_labels = sorted(labels)
+
+    metadata = DatasetMetadata(
+        sorted_labels=sorted_labels,
+        label_to_id={label: i for i, label in enumerate(sorted_labels)},
+        id_to_label={i: label for i, label in enumerate(sorted_labels)},
+    )
+    return metadata
+
 def load_augmented_back_translation(train_path: str, test_path: str) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Load pre-split augmented training set and untouched test set for back translation.
 
@@ -315,25 +329,16 @@ def transform_data_advanced(data, rare_threshold: int = 2):
         Logger.info(f"Advanced text: {sample.text}")
         Logger.info("#" * 20 + "\n")
 
-    return processed_samples
-
+    # Generate metadata
+    processed_metadata = _build_dataset_metadata(processed_samples)
+    return processed_samples, processed_metadata
 
 def transform_data(data: list[dict]) -> tuple[list[DatasetItem], DatasetMetadata]:
     # Preprocess data
     preprocessed_samples = _preprocess_sample(data)
 
     # Generate metadata
-    labels = set([s.label for s in preprocessed_samples])
-
-    # Sort and print unique labels
-    sorted_labels = sorted(labels)
-
-    preprocessed_metadata = DatasetMetadata(
-        sorted_labels=sorted_labels,
-        label_to_id={label: i for i, label in enumerate(sorted_labels)},
-        id_to_label={i: label for i, label in enumerate(sorted_labels)},
-    )
-
+    preprocessed_metadata = _build_dataset_metadata(preprocessed_samples)
     return preprocessed_samples, preprocessed_metadata
 
 
@@ -354,3 +359,4 @@ def split_dataset(
     Logger.info(f"Test samples: {len(x_test)}")
 
     return x_train, x_test, y_train, y_test
+


### PR DESCRIPTION
Fix https://github.com/aio25-mix002/m03-p0301/issues/19
Problem
- Advanced Data processing with Error loading dataset: 'Dataitem' object is not iterable when building the dataset.

Root cause
- The loader returns list [DataItem] instance where the caller expects a tuple with two properties